### PR TITLE
Remove references to breaking upstream data source

### DIFF
--- a/bikes-per-week.ipynb
+++ b/bikes-per-week.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "In this notebook we will look at how the total number of cyclists varies across the year and what the distribution of cyclists looks like on an average day.\n",
     "\n",
-    "The year 2017 is not over yet, so we will use data from 2016 instead.\n",
+    "Let's use data from 2015.\n",
     "\n",
     "To get started we import a few libraries that we will need later:"
    ]
@@ -71,7 +71,7 @@
     "Fetch the data from the city of Zurich server and load it into a [pandas](http://pandas.pydata.org/) dataframe. We can think of a pandas dataframe as an Excel spreadsheet that can be manipulated by programming instead of clicking buttons.\n",
     "\n",
     "There are two things we need to know in order to load the data:\n",
-    "1. which year we are interested in, in our case 2016\n",
+    "1. which year we are interested in, in our case 2015\n",
     "1. which of the many bike counters we want to look at\n",
     "\n",
     "The bike counters are specified with their own special naming system. This means their names are things like \"ECO09113499\" or \"U15G3104442\". Not exactly human friendly. It makes sense though as the counters themselves have been in use for many years during which they might have been moved from one location to another. We will focus on a counter that has been placed at Mythenquai for a long time. It is named: \"ECO09113499\". To find out what counters at other locations are called visit: XXX and check when they were located where.\n",
@@ -87,7 +87,7 @@
    },
    "outputs": [],
    "source": [
-    "mythenquai = get_velo_data('ECO09113499', year=2016)"
+    "mythenquai = get_velo_data('ECO09113499', year=2015)"
    ]
   },
   {

--- a/utils.py
+++ b/utils.py
@@ -8,13 +8,12 @@ import pandas as pd
 def get_velo_data(location, year=2016):
     BASE = "https://data.stadt-zuerich.ch/dataset/verkehrszaehlungen_werte_fussgaenger_velo/resource/"
     URLS = {
-        2016: BASE + "ed354dde-c0f9-43b3-b05b-08c5f4c3f65a/download/2016verkehrszaehlungenwertefussgaengervelo.csv",
         2015: BASE + "5c994056-eda6-48c5-8e61-28e96bcd04a3/download/2015verkehrszaehlungenwertefussgaengervelo.csv",
         2014: BASE + "bd2c9dd9-5b05-4303-a4c9-4a9f5b73e8f7/download/2014verkehrszaehlungenwertefussgaengervelo.csv",
         }
 
     if year not in URLS:
-        raise ValueError("Year has to be one of 2014, 2015, 2016 "
+        raise ValueError("Year has to be one of 2014, 2015 "
                          "not %s." % year)
 
     fname = "bikes-%i.csv" % year


### PR DESCRIPTION
The upstream data source uses different field names for 2016 data, so the notebook does not run (error on data import). 2014 and 2015 data still run fine with the old field names, so I just removed references to 2016. 

(A little background--I found this notebook linked from the elife blog post introducing Binder 2.0, here: https://elifesciences.org/labs/8653a61d/introducing-binder-2-0-share-your-interactive-research-environment
)